### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Currently supports git & jenkins.
 .. image:: https://coveralls.io/repos/futurecolors/redmine-releasedate/badge.png?branch=master
     :target: https://coveralls.io/r/futurecolors/redmine-releasedate
 
-.. image:: https://pypip.in/v/redmine-releasedate/badge.png
+.. image:: https://img.shields.io/pypi/v/redmine-releasedate.svg
     :target: https://crate.io/packages/redmine-releasedate/
 
 How it works


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20redmine-releasedate))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `redmine-releasedate`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.